### PR TITLE
Fix issue with _compute_qty not passing correct parameter reference

### DIFF
--- a/smile_product_uom_multi/models/product.py
+++ b/smile_product_uom_multi/models/product.py
@@ -111,7 +111,7 @@ class ProductUom(models.Model):
             from_unit, to_unit = uoms[0], uoms[-1]
         else:
             from_unit, to_unit = uoms[-1], uoms[0]
-        return self._compute_qty_obj(cr, uid, from_unit, qty, to_unit, round, context)
+        return self._compute_qty_obj(cr, uid, from_unit, qty, to_unit, round, context=context)
 
     def _convert_qty(self, cr, uid, qty, unit, product, is_from_unit=True):
         import operator


### PR DESCRIPTION
_compute_qty_obj was changed to add parameter "rounding_method" (default UP) to _compute_qty_obj.

_compute_qty though was not modified for this change and does not pass parameter names as references to _compute_qty_obj, therefor causing an error when modifying quantities on sale.order.line. 

Fix is to simply reference context=context so that the default value of rounding_method is selected.