### PR TITLE
FIX _get_report_from_name does not accept context parameter

### DIFF
--- a/smile_report/controllers/main.py
+++ b/smile_report/controllers/main.py
@@ -62,7 +62,7 @@ def report_download(self, data, token):
 
             # Added by Smile
             registry, cr, uid, context = request.registry, request.cr, request.session.uid, request.context
-            report = registry['report']._get_report_from_name(cr, uid, reportname, context)
+            report = registry['report']._get_report_from_name(cr, uid, reportname)
             if docids:
                 docids = [int(i) for i in docids.split(',')]
             if report.attachment and docids and len(docids) == 1:


### PR DESCRIPTION
addon: smile_report
impact: all print actions

issue: _get_report_from_name does not accept context,
TypeError: _get_report_from_name() takes exactly 4 arguments (5 given)