### PR TITLE
9.0 - Replace user_ids by a smart button.

### DIFF
--- a/smile_access_control/i18n/fr.po
+++ b/smile_access_control/i18n/fr.po
@@ -69,8 +69,8 @@ msgstr "Correspond à un profil utilisateur"
 
 #. module: smile_access_control
 #: model:ir.ui.view,arch_db:smile_access_control.view_user_profile_form
-msgid "Linked users"
-msgstr "Utilisateurs associés"
+msgid "Users"
+msgstr "Utilisateurs"
 
 #. module: smile_access_control
 #: model:ir.model,name:smile_access_control.model_ir_model

--- a/smile_access_control/models/res_users.py
+++ b/smile_access_control/models/res_users.py
@@ -116,7 +116,7 @@ class ResUsers(models.Model):
     @api.multi
     def _update_users_linked_to_profile(self, fields=None):
         for user_profile in self.filtered(lambda user: user.is_user_profile and user.is_update_users):
-            users = self.search([('user_profile_id', '=', user_profile)])
+            users = self.search([('user_profile_id', '=', user_profile.id)])
             users.with_context(active_test=False)._update_from_profile(fields)
 
     @api.model

--- a/smile_access_control/views/res_users_view.xml
+++ b/smile_access_control/views/res_users_view.xml
@@ -38,7 +38,7 @@
 
     <!-- Profiles -->
     <!-- Add page for technical profile configuration-->
-    
+
     <record id="view_user_profile_form" model="ir.ui.view">
       <field name="name">res.users.form</field>
       <field name="model">res.users</field>
@@ -56,12 +56,15 @@
               <field name="is_user_profile" invisible="1"/>
               <field name="is_update_users" attrs="{'invisible': [('is_user_profile', '=', False)]}"/>
               <label for="is_update_users"/>
-              <separator string="Linked users" colspan="4"/>
-              <field name="user_ids" nolabel="1" colspan="4" widget="many2many" context="{'form_view_ref': 'base.view_users_form'}"/>
               <separator string="Fields to update for linked users" colspan="4"/>
               <field name="field_ids" nolabel="1" colspan="4"/>
             </page>
           </notebook>
+          <div name="button_box" position="inside">
+            <button class="oe_inline oe_stat_button" name="button_show_users" type="object" icon="fa-users">
+                <field string="Users" name="user_count" widget="statinfo"/>
+            </button>
+          </div>
         </data>
       </field>
     </record>


### PR DESCRIPTION
[IMP] When more than ~3K linked users on a profile, the view takes forever to load.
Fixed this by removing the one2many field 'user_ids' and putting a smart button instead. 