### PR TITLE
Lazy property bug fix

### DIFF
--- a/smile_redis_session_store/redis_session_store.py
+++ b/smile_redis_session_store/redis_session_store.py
@@ -94,10 +94,5 @@ if is_redis_session_store_activated():
         # Override to ignore file unlink because sessions are not stored in files
         pass
 
-    @lazy_property
-    def session_store(self):
-        # Override to use Redis instead of filestystem
-        return RedisSessionStore(session_class=http.OpenERPSession)
-
     http.session_gc = session_gc
-    http.Root.session_store = session_store
+    http.root.session_store = RedisSessionStore(session_class=http.OpenERPSession)


### PR DESCRIPTION
re-declaring the lazy property is not always working depending on when in the startup chain the call to get the session store is used.  This can be before the lazy property is re-declared.  However this can be directly set on the singleton property and this results in proper functionality.  However we loose lazy loading.  This however is not a problem because the session store will definitely always be required, so the lazy loading is not providing anything for us.