### PR TITLE
Add unix socket option to redis session store

### DIFF
--- a/smile_redis_session_store/README.rst
+++ b/smile_redis_session_store/README.rst
@@ -41,7 +41,9 @@ Available options
 * `redis_port` (default: 6379): Redis port
 * `redis_dbindex` (default: 1): Redis database index
 * `redis_pass` (default: None): Redis password
+* `redis_socket` (default: None) :  unix socket path
 
+If `redis_socket` is used, both `redis_host` and `redis_port` should be None.
 
 Bug Tracker
 ===========

--- a/smile_redis_session_store/redis_session_store.py
+++ b/smile_redis_session_store/redis_session_store.py
@@ -48,10 +48,19 @@ class RedisSessionStore(werkzeug.contrib.sessions.SessionStore):
         super(RedisSessionStore, self).__init__(*args, **kwargs)
         self.expire = kwargs.get('expire', SESSION_TIMEOUT)
         self.key_prefix = kwargs.get('key_prefix', '')
+<<<<<<< HEAD
         self.redis = redis.Redis(host=tools.config.get('redis_host', 'localhost'),
                                  port=int(tools.config.get('redis_port', 6379)),
                                  db=int(tools.config.get('redis_dbindex', 1)),
                                  password=tools.config.get('redis_pass', None))
+=======
+        self.redis = redis.Redis(
+            host=tools.config.get('redis_host', 'localhost'),
+            port=int(tools.config.get('redis_port', 6379)),
+            db=int(tools.config.get('redis_dbindex', 1)),
+            password=tools.config.get('redis_pass', None),
+            unix_socket_path=tools.config.get('redis_socket', None))
+>>>>>>> a09d7c75... Add unix socket option for redis
         self._is_redis_server_running()
 
     def save(self, session):

--- a/smile_redis_session_store/static/description/index.html
+++ b/smile_redis_session_store/static/description/index.html
@@ -364,7 +364,9 @@ in configuration file.</p>
 <li><cite>redis_port</cite> (default: 6379): Redis port</li>
 <li><cite>redis_dbindex</cite> (default: 1): Redis database index</li>
 <li><cite>redis_pass</cite> (default: None): Redis password</li>
+<li><cite>redis_socket</cite> (default: None) :  unix socket path</li>
 </ul>
+<p>If <cite>redis_socket</cite> is used, both <cite>redis_host</cite> and <cite>redis_port</cite> should be None.</p>
 </div>
 </div>
 <div class="section" id="bug-tracker">


### PR DESCRIPTION
This commit adds unix socket option for redis session store. Using the option requires that both `redis_host` and `redis_port` should be None. If no unix socket is supplied, the behavior doesn't change at all. This commit can be applies to both branches 11.0 and 12.0 as is.

This is one possible solution to issue #56 