### PR TITLE
Add UNIX socket support for redis session store

### DIFF
--- a/smile_redis_session_store/README.rst
+++ b/smile_redis_session_store/README.rst
@@ -25,14 +25,14 @@ You need to install package `redis`::
 
     pip install redis
 
-.. _`Redis website`: http://redis.io/topics/quickstart 
+.. _`Redis website`: http://redis.io/topics/quickstart
 
 
 Usage
 =====
 
 To use Redis, install this module and please add `enable_redis = True` option
-in configuration file. 
+in configuration file.
 
 Available options
 -----------------
@@ -41,7 +41,9 @@ Available options
 * `redis_port` (default: 6379): Redis port
 * `redis_dbindex` (default: 1): Redis database index
 * `redis_pass` (default: None): Redis password
+* `redis_socket` (default: None) :  unix socket path
 
+If `redis_socket` is used, both `redis_host` and `redis_port` should be None.
 
 Bug Tracker
 ===========

--- a/smile_redis_session_store/redis_session_store.py
+++ b/smile_redis_session_store/redis_session_store.py
@@ -48,8 +48,13 @@ class RedisSessionStore(werkzeug.contrib.sessions.SessionStore):
         super(RedisSessionStore, self).__init__(*args, **kwargs)
         self.expire = kwargs.get('expire', SESSION_TIMEOUT)
         self.key_prefix = kwargs.get('key_prefix', '')
+        _port = tools.config.get('redis_port', 6379)
+        try:
+            _port = int(_port)
+        except ValueError:
+            _port = None
         self.redis = redis.Redis(host=tools.config.get('redis_host', 'localhost'),
-                                 port=int(tools.config.get('redis_port', 6379)),
+                                 port=_port,
                                  db=int(tools.config.get('redis_dbindex', 1)),
                                  password=tools.config.get('redis_pass', None),
                                  unix_socket_path=tools.config.get('redis_socket', None))

--- a/smile_redis_session_store/redis_session_store.py
+++ b/smile_redis_session_store/redis_session_store.py
@@ -51,7 +51,8 @@ class RedisSessionStore(werkzeug.contrib.sessions.SessionStore):
         self.redis = redis.Redis(host=tools.config.get('redis_host', 'localhost'),
                                  port=int(tools.config.get('redis_port', 6379)),
                                  db=int(tools.config.get('redis_dbindex', 1)),
-                                 password=tools.config.get('redis_pass', None))
+                                 password=tools.config.get('redis_pass', None),
+                                 unix_socket_path=tools.config.get('redis_socket', None))
         self._is_redis_server_running()
 
     def save(self, session):

--- a/smile_redis_session_store/static/description/index.html
+++ b/smile_redis_session_store/static/description/index.html
@@ -3,13 +3,13 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.12: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils 0.14: http://docutils.sourceforge.net/" />
 <title>Redis Session Store</title>
 <style type="text/css">
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 7614 2013-02-21 15:55:51Z milde $
+:Id: $Id: html4css1.css 7952 2016-07-26 18:15:59Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
@@ -36,6 +36,14 @@ table.borderless td, table.borderless th {
 
 .hidden {
   display: none }
+
+.subscript {
+  vertical-align: sub;
+  font-size: smaller }
+
+.superscript {
+  vertical-align: super;
+  font-size: smaller }
 
 a.toc-backref {
   text-decoration: none ;
@@ -161,18 +169,23 @@ h2.subtitle {
 hr.docutils {
   width: 75% }
 
-img.align-left, .figure.align-left, object.align-left {
+img.align-left, .figure.align-left, object.align-left, table.align-left {
   clear: left ;
   float: left ;
   margin-right: 1em }
 
-img.align-right, .figure.align-right, object.align-right {
+img.align-right, .figure.align-right, object.align-right, table.align-right {
   clear: right ;
   float: right ;
   margin-left: 1em }
 
 img.align-center, .figure.align-center, object.align-center {
   display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+table.align-center {
   margin-left: auto;
   margin-right: auto;
 }
@@ -193,6 +206,15 @@ div.align-right {
 
 /* div.align-center * { */
 /*   text-align: left } */
+
+.align-top    {
+  vertical-align: top }
+
+.align-middle {
+  vertical-align: middle }
+
+.align-bottom {
+  vertical-align: bottom }
 
 ol.simple, ul.simple {
   margin-bottom: 1em }
@@ -348,9 +370,9 @@ instead of classic filesystem storage.</p>
 <h1>Requirements</h1>
 <p>You need to install and to start a Redis server to use this module.
 Documentation is available on <a class="reference external" href="http://redis.io/topics/quickstart">Redis website</a>.</p>
-<p>You need to install package <cite>python-redis</cite>:</p>
+<p>You need to install package <cite>redis</cite>:</p>
 <pre class="literal-block">
-apt-get install python-redis
+pip install redis
 </pre>
 </div>
 <div class="section" id="usage">
@@ -364,7 +386,9 @@ in configuration file.</p>
 <li><cite>redis_port</cite> (default: 6379): Redis port</li>
 <li><cite>redis_dbindex</cite> (default: 1): Redis database index</li>
 <li><cite>redis_pass</cite> (default: None): Redis password</li>
+<li><cite>redis_socket</cite> (default: None) :  unix socket path</li>
 </ul>
+<p>If <cite>redis_socket</cite> is used, both <cite>redis_host</cite> and <cite>redis_port</cite> should be None.</p>
 </div>
 </div>
 <div class="section" id="bug-tracker">


### PR DESCRIPTION
This commit adds unix socket option for redis session store. Using the option requires that both redis_host and redis_port should be None. If no unix socket is supplied, the behavior doesn't change at all. This commit can be applies to both branches 11.0 and 12.0 as is.

This is one possible solution to issue #56

