### PR TITLE
Fix javascript code of smile_web_impex

### DIFF
--- a/smile_web_impex/models/__init__.py
+++ b/smile_web_impex/models/__init__.py
@@ -1,5 +1,6 @@
-# -*- coding: utf-8 -*-
 # (C) 2019 Smile (<http://www.smile.fr>)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
-from . import models
+from . import (
+    ir_http,
+)

--- a/smile_web_impex/models/ir_http.py
+++ b/smile_web_impex/models/ir_http.py
@@ -1,0 +1,15 @@
+# (C) 2019 Smile (<http://www.smile.fr>)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+
+    _inherit = 'ir.http'
+
+    def session_info(self):
+        result = super().session_info()
+        result['has_group_smile_import'] = self.env.user.has_group('smile_web_impex.group_import')
+        result['has_group_smile_export'] = self.env.user.has_group('smile_web_impex.group_export')
+        return result

--- a/smile_web_impex/static/src/js/web_impex.js
+++ b/smile_web_impex/static/src/js/web_impex.js
@@ -6,6 +6,7 @@ odoo.define('web_impex', function (require) {
     var KanbanController = require('web.KanbanController');
     var ListController = require("web.ListController");
     var _t = core._t;
+    var session = require("web.session");
 
     KanbanController.include({
         /**
@@ -14,16 +15,8 @@ odoo.define('web_impex', function (require) {
         renderButtons: function () {
             this._super.apply(this, arguments); // Sets this.$buttons
 
-            var has_import_group = false;
-            this.getSession().user_has_group('smile_web_impex.group_import').then(function(has_group) {
-                if(has_group) {
-                    has_import_group = true;
-                } else {
-                    has_import_group = false;
-                }
-            });
-
-            if (!has_import_group && this.$buttons != undefined) {
+            var has_import_group = session.has_group_smile_import;
+            if (!has_import_group && this.$buttons !== undefined) {
                 this.$buttons.find('.o_button_import').hide();
             }
         },
@@ -37,16 +30,8 @@ odoo.define('web_impex', function (require) {
         renderButtons: function () {
             this._super.apply(this, arguments); // Sets this.$buttons
 
-            var has_import_group = false;
-            this.getSession().user_has_group('smile_web_impex.group_import').then(function(has_group) {
-                if(has_group) {
-                    has_import_group = true;
-                } else {
-                    has_import_group = false;
-                }
-            });
-
-            if (!has_import_group && this.$buttons != undefined) {
+            var has_import_group = session.has_group_smile_import;
+            if (!has_import_group && this.$buttons !== undefined) {
                 this.$buttons.find('.o_button_import').hide();
             }
         },
@@ -56,18 +41,9 @@ odoo.define('web_impex', function (require) {
          */
         renderSidebar: function ($node) {
             if (this.hasSidebar && !this.sidebar) {
-
-                var has_export_group = false;
-                this.getSession().user_has_group('smile_web_impex.group_export').then(function(has_group) {
-                    if(has_group) {
-                        has_export_group = true;
-                    } else {
-                        has_export_group = false;
-                    }
-                });
-
                 var other = [];
 
+                var has_export_group = session.has_group_smile_export;
                 if (has_export_group) {
                     other.push({
                         label: _t("Export"),


### PR DESCRIPTION
Using a callback to evaluate whether the button should be hidden
does not always work. The callback is not guaranteed to be called instantaneously.

For example, when refreshing the screen, the export button disapears.

Instead, use the session to store flags to indicate whether the user is member of
the import/export groups.