### PR TITLE
[FIX] smile_audit: fix 'two fields have the same label' warning

### DIFF
--- a/smile_audit/models/audit_log.py
+++ b/smile_audit/models/audit_log.py
@@ -22,7 +22,7 @@ class AuditLog(models.Model):
     model_id = fields.Many2one(
         'ir.model', 'Model', required=True, readonly=True)
     model = fields.Char(
-        related='model_id.model', store=True, readonly=True, index=True)
+        'Model Name', related='model_id.model', store=True, readonly=True, index=True)
     res_id = fields.Integer('Resource Id', readonly=True)
     method = fields.Char('Method', size=64, readonly=True)
     data = fields.Text('Data', readonly=True)


### PR DESCRIPTION
When the tests are enabled, the odoo log file displays several warnings:
  Two fields (model, model_id) of audit.log() have the same label: Model.

This prevents a clean install on Odoo.sh. The branch appear in orange color instead of green.

Closes: #47