### PR TITLE
[FIX] smile_base_automation - fixing group access error

### DIFF
--- a/smile_base_automation/README.rst
+++ b/smile_base_automation/README.rst
@@ -59,6 +59,7 @@ Contributors
 
 * Corentin Pouhet-Brunerie
 * Majda EL MARIOULI
+* Justinas Orechovas <jorechovas@archeti.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/smile_base_automation/models/ir_actions.py
+++ b/smile_base_automation/models/ir_actions.py
@@ -28,7 +28,7 @@ class ServerAction(models.Model):
 
     def run(self):
         res = False
-        for action in self:
+        for action in self.sudo():
             if action.execution_mode == 'synchronous' or \
                     self._context.get('force_execution'):
                 res = super(ServerAction, action).run()


### PR DESCRIPTION
Added .sudo() in loop. Before it caused group access error when calling ir.actions.server from Actions.

Odoo's fix commit - https://github.com/odoo/odoo/commit/f0d37c384b299e5f35cddda02d3f56c6ad37a9a7#diff-adb623c0597ff852c07f767f6bc514ef31036795728b8382a6a88ea81b67bb59R567

