### PR TITLE
Restore `granularity` key in `annotated_groupbys`

### DIFF
--- a/smile_base/models/base.py
+++ b/smile_base/models/base.py
@@ -207,6 +207,7 @@ class Base(models.AbstractModel):
                 'type': field_type,
                 'display_format': display_formats[gb_function or 'month'],
                 'interval': time_intervals[gb_function or 'month'],
+                'granularity': gb_function or 'month',
                 'tz_convert': tz_convert,
                 'qualified_field': qualified_field,
             }


### PR DESCRIPTION
Odoo will raise the following error when we try to show the `Sales` report:  

```
  File "/home/lubuntu/odoo-15.0/odoo/models.py", line 2144, in _read_group_fill_temporal
    granularity = first_a_gby['granularity']
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/lubuntu/odoo-15.0/odoo/http.py", line 643, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/lubuntu/odoo-15.0/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
KeyError: 'granularity'
```